### PR TITLE
Add Virtual Forge to the list of haskell using companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The following is a list of members of the group. Everyone is welcome to be part 
 * Tsuru Capital
 * VaryWell
 * VFILES
+* Virtual Forge
 * Wagon
 * Wellposed
 * Well-Typed


### PR DESCRIPTION
Hi, we're currently developing new code using haskell for the server side, which should go online in the not-so-distant future. It'd be awesome to be on the list. ;-)

I didn't find a way to join the mailing list without a google account -- if possible, could you add the author's/committer's e-mail address of this pull request to the commercial haskell ML?

Many thanks,
HC